### PR TITLE
Show links to turbo frames

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Turbo devtools",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Easily locate turbo-frames with this simple developer tools for Turbo Frames",
   "manifest_version": 3,
   "icons": {

--- a/turbo-frame/debug.css
+++ b/turbo-frame/debug.css
@@ -1,18 +1,29 @@
-turbo-frame {
-  border: 1px red solid;
+turbo-frame, a[data-turbo-frame] {
+  border: 1px darkred solid;
   display: block;
 }
 
 turbo-frame::before {
-  content: "Frame: #" attr(id);
+  content: "#" attr(id);
+}
+
+a[data-turbo-frame]:hover:before {
+  content: "Link to #" attr(data-turbo-frame);
+  position: fixed;
+  top: 0;
+  right: 0;
+}
+
+turbo-frame::before, a[data-turbo-frame]::before {
   position: relative;
   top: -14px;
   right: -4px;
   display: inline-block;
-  color: red;
+  color: darkred;
   font-size: 12px;
   z-index: 9999;
   background-color: white;
   padding: 4px;
-  border: 1px red solid;
+  border: 1px darkred solid;
 }
+


### PR DESCRIPTION

## Purpose
Per request in Issue https://github.com/lcampanari/turbo-devtools/issues/1 this shows links to turbo frames to the developer along with the id of the frame when you hover over the link.

## Approach
Use similar CSS technique to cover the a[data-turbo-frame] elements.
Switch to darkred as the main color. Easier on my eyes in dark mode.

## Screenshot/Video
This example is from https://github.com/tpaulshippy/counting (had to add some frames and links to demonstrate).

https://github.com/lcampanari/turbo-devtools/assets/3137263/1a8b9936-6c25-48e7-a0dd-db3477eacbe7

