### PR TITLE
Remove display style from turbo-frame

### DIFF
--- a/turbo-frame/debug.css
+++ b/turbo-frame/debug.css
@@ -1,6 +1,5 @@
 turbo-frame {
   border: 1px red solid;
-  display: block;
 }
 
 turbo-frame::before {


### PR DESCRIPTION
## Purpose
Setting the display on the frame can affect how the contents within it display. In one case, we had a scrollable div that become no longer scrollable because of this CSS.

## Approach
Remove the `display: block` for the frame.
