### PR TITLE
Add Turbo logging

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,8 +1,26 @@
-chrome.action.onClicked.addListener(tab => {
-  if (!tab.url.includes('chrome://')) {
-    chrome.scripting.executeScript({
-      target: { tabId: tab.id },
-      files: ['turbo-frame/init.js']
-    })
+
+chrome.action.onClicked.addListener(async (tab) => {
+  if (tab.url.includes('chrome://')) return;
+
+  const prevState = await chrome.action.getBadgeText({ tabId: tab.id });
+  const nextState = prevState === 'ON' ? 'OFF' : 'ON'
+
+  chrome.action.setBadgeText({
+    text: nextState,
+    tabId: tab.id,
+  });
+
+  chrome.scripting.executeScript({
+    target: { tabId: tab.id },
+    files: ['turbo-frame/init.js']
+  })
+});
+
+chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+  if (changeInfo.status === 'loading') {
+    chrome.action.setBadgeText({
+      text: "OFF",
+      tabId: tabId,
+    });
   }
-})
+});

--- a/background.js
+++ b/background.js
@@ -1,28 +1,8 @@
-function toggleDebugStylesheet() {
-  var path = 'turbo-frame/debug.css'
-  var href = chrome.runtime.getURL(path)
-  var linkElement = document.querySelectorAll('link[href="' + href + '"]')[0]
-  var turboFrames = document.querySelectorAll('turbo-frame')
-
-  if (!turboFrames.length) return
-
-  if (linkElement) {
-    linkElement.remove()
-  } else {
-    var head = document.getElementsByTagName('head')[0]
-    var link = document.createElement('link')
-    link.rel = 'stylesheet'
-    link.type = 'text/css'
-    link.href = chrome.runtime.getURL(path)
-    head.appendChild(link)
-  }
-}
-
 chrome.action.onClicked.addListener(tab => {
   if (!tab.url.includes('chrome://')) {
     chrome.scripting.executeScript({
       target: { tabId: tab.id },
-      function: toggleDebugStylesheet
+      files: ['turbo-frame/debug.js']
     })
   }
 })

--- a/background.js
+++ b/background.js
@@ -2,7 +2,7 @@ chrome.action.onClicked.addListener(tab => {
   if (!tab.url.includes('chrome://')) {
     chrome.scripting.executeScript({
       target: { tabId: tab.id },
-      files: ['turbo-frame/debug.js']
+      files: ['turbo-frame/init.js']
     })
   }
 })

--- a/manifest.json
+++ b/manifest.json
@@ -15,7 +15,7 @@
   },
   "web_accessible_resources": [
     {
-      "resources": ["turbo-frame/debug.css", "turbo-frame/debug.js"],
+      "resources": ["turbo-frame/debug.css", "turbo-frame/debug.js", "turbo-frame/init.js"],
       "matches": ["*://*/*"]
     }
   ]

--- a/manifest.json
+++ b/manifest.json
@@ -15,7 +15,7 @@
   },
   "web_accessible_resources": [
     {
-      "resources": ["turbo-frame/debug.css"],
+      "resources": ["turbo-frame/debug.css", "turbo-frame/debug.js"],
       "matches": ["*://*/*"]
     }
   ]

--- a/turbo-frame/debug.js
+++ b/turbo-frame/debug.js
@@ -3,6 +3,7 @@ class TurboDebugLogger {
 
     constructor() {
         this.handleTurboClick = this.handleTurboClick.bind(this);
+        this.handleTurboVisit = this.handleTurboVisit.bind(this);
         this.handleTurboBeforePrefetch = this.handleTurboBeforePrefetch.bind(this);
         this.handleTurboBeforeFetchRequest = this.handleTurboBeforeFetchRequest.bind(this);
         this.handleTurboBeforeStreamRender = this.handleTurboBeforeStreamRender.bind(this);
@@ -12,6 +13,7 @@ class TurboDebugLogger {
 
     setupEventListeners() {
         document.addEventListener('turbo:click', this.handleTurboClick);
+        document.addEventListener('turbo:visit', this.handleTurboVisit);        
         document.addEventListener('turbo:before-prefetch', this.handleTurboBeforePrefetch);
         document.addEventListener('turbo:before-fetch-request', this.handleTurboBeforeFetchRequest);
         document.addEventListener('turbo:before-stream-render', this.handleTurboBeforeStreamRender);
@@ -43,7 +45,11 @@ class TurboDebugLogger {
         this.logMessage(event, 
             `Link with text "${event.target.innerText}" click was intercepted. Turbo will`,
             clickMessage);
+    }
 
+    handleTurboVisit(event) {
+        this.logMessage(event,
+            `Navigating to ${event.detail.url} with action "${event.detail.action}".`);
     }
 
     handleTurboBeforePrefetch(event) {

--- a/turbo-frame/debug.js
+++ b/turbo-frame/debug.js
@@ -1,90 +1,80 @@
-if (!window.turboFrameDebug) {
 
-    class TurboFrameDebug {
+class TurboDebugLogger {
 
-        constructor() {
-            this.debugStylesheetPath = 'turbo-frame/debug.css';
-            this.enabled = false;
-            this.handleTurboClick = this.handleTurboClick.bind(this);
-            this.handleTurboBeforePrefetch = this.handleTurboBeforePrefetch.bind(this);
-            this.handleTurboBeforeFetchRequest = this.handleTurboBeforeFetchRequest.bind(this);
-            this.handleTurboBeforeStreamRender = this.handleTurboBeforeStreamRender.bind(this);
-        }
+    constructor() {
+        this.handleTurboClick = this.handleTurboClick.bind(this);
+        this.handleTurboBeforePrefetch = this.handleTurboBeforePrefetch.bind(this);
+        this.handleTurboBeforeFetchRequest = this.handleTurboBeforeFetchRequest.bind(this);
+        this.handleTurboBeforeStreamRender = this.handleTurboBeforeStreamRender.bind(this);
 
-        toggleDebug() {
-            this.enabled = !this.enabled;
-            if (this.enabled) {
-                this.setupEventListeners();
-            }
-            else {
-                this.removeEventListeners();
+    }
 
-            }
-        }
 
-        setupEventListeners() {
-            document.addEventListener('turbo:click', this.handleTurboClick);
-            document.addEventListener('turbo:before-prefetch', this.handleTurboBeforePrefetch);
-            document.addEventListener('turbo:before-fetch-request', this.handleTurboBeforeFetchRequest);
-            document.addEventListener('turbo:before-stream-render', this.handleTurboBeforeStreamRender);
-        }
+    setupEventListeners() {
+        document.addEventListener('turbo:click', this.handleTurboClick);
+        document.addEventListener('turbo:before-prefetch', this.handleTurboBeforePrefetch);
+        document.addEventListener('turbo:before-fetch-request', this.handleTurboBeforeFetchRequest);
+        document.addEventListener('turbo:before-stream-render', this.handleTurboBeforeStreamRender);
+    }
 
-        removeEventListeners() {
-            document.removeEventListener('turbo:click', this.handleTurboClick);
-            document.removeEventListener('turbo:before-prefetch', this.handleTurboBeforePrefetch);
-            document.removeEventListener('turbo:before-fetch-request', this.handleTurboBeforeFetchRequest);
-            document.removeEventListener('turbo:before-stream-render', this.handleTurboBeforeStreamRender);
-        }
+    removeEventListeners() {
+        document.removeEventListener('turbo:click', this.handleTurboClick);
+        document.removeEventListener('turbo:before-prefetch', this.handleTurboBeforePrefetch);
+        document.removeEventListener('turbo:before-fetch-request', this.handleTurboBeforeFetchRequest);
+        document.removeEventListener('turbo:before-stream-render', this.handleTurboBeforeStreamRender);
+    }
 
-        handleTurboClick(event) {
-            const frameId = this.getFrameId(event.target);
-            console.log(`%c${event.target.innerText}`,
-                'font-weight: bold; text-decoration: underline;',
-                'click was intercepted by Turbo which will',
-                `replace the contents of #${frameId} with the contents of <turbo-frame id="${frameId}"></turbo-frame> returned from ${event.detail.url}`,
-                event)
+    handleTurboClick(event) {
+        const frameId = this.getFrameId(event.target);
+        console.log(`%c${event.target.innerText}`,
+            'font-weight: bold; text-decoration: underline;',
+            'click was intercepted by Turbo which will',
+            `replace the contents of #${frameId} with the contents of <turbo-frame id="${frameId}"></turbo-frame> returned from ${event.detail.url}`,
+            event)
 
-        }
+    }
 
-        handleTurboBeforePrefetch(event) {
-            console.log(`%c${event.target.innerText}`,
+    handleTurboBeforePrefetch(event) {
+        console.log(`%c${event.target.innerText}`,
             'font-weight: bold; text-decoration: underline;',
             'hover was intercepted by Turbo which will',
             `prefetch.`,
             event);
+    }
+
+    handleTurboBeforeFetchRequest(event) {
+        console.log(`Turbo is fetching ${event.detail.url}`, event);
+    }
+
+    handleTurboBeforeStreamRender(event) {
+        let action = event.target.getAttribute('action');
+        if (action == 'before' || action == 'after') {
+            console.log(`Turbo has received a stream of html that will insert the contents of the template received ${action} the contents of #${event.target.getAttribute('target')}`, event)
         }
-
-        handleTurboBeforeFetchRequest(event) {
-            console.log(`Turbo is fetching ${event.detail.url}`, event);
-        }
-
-        handleTurboBeforeStreamRender(event) {
-            let action = event.target.getAttribute('action');
-            if (action == 'before' || action == 'after') {
-                console.log(`Turbo has received a stream of html that will insert the contents of the template received ${action} the contents of #${event.target.getAttribute('target')}`, event)
-            }
-            else {
-                console.log(`Turbo has received a stream of html that will ${action} the contents of #${event.target.getAttribute('target')} with the contents of the template received`, event)
-            }
-
-        }
-
-        getFrameId(element) {
-            const frameId = element.getAttribute('data-turbo-frame');
-            if (!frameId) {
-                while (element.parentElement) {
-                    if (element.localName === 'turbo-frame') {
-                        const parentFrameId = element.id;
-                        return parentFrameId;
-                    }
-                    element = element.parentElement;
-                }
-            }
-            return frameId;
+        else {
+            console.log(`Turbo has received a stream of html that will ${action} the contents of #${event.target.getAttribute('target')} with the contents of the template received`, event)
         }
 
     }
 
-    window.turboFrameDebug = new TurboFrameDebug();
+    getFrameId(element) {
+        const frameId = element.getAttribute('data-turbo-frame');
+        if (!frameId) {
+            while (element.parentElement) {
+                if (element.localName === 'turbo-frame') {
+                    const parentFrameId = element.id;
+                    return parentFrameId;
+                }
+                element = element.parentElement;
+            }
+        }
+        return frameId;
+    }
+
 }
-window.turboFrameDebug.toggleDebug();
+
+if (!window.turboDebugLogger)
+{
+    window.turboDebugLogger = new TurboDebugLogger();
+    window.turboDebugLogger.setupEventListeners();
+}

--- a/turbo-frame/debug.js
+++ b/turbo-frame/debug.js
@@ -6,13 +6,13 @@ if (!window.turboFrameDebug) {
             this.debugStylesheetPath = 'turbo-frame/debug.css';
             this.enabled = false;
             this.handleTurboClick = this.handleTurboClick.bind(this);
-            this.handleTurboBeforeFetchResponse = this.handleTurboBeforeFetchResponse.bind(this);
+            this.handleTurboBeforePrefetch = this.handleTurboBeforePrefetch.bind(this);
+            this.handleTurboBeforeFetchRequest = this.handleTurboBeforeFetchRequest.bind(this);
             this.handleTurboBeforeStreamRender = this.handleTurboBeforeStreamRender.bind(this);
         }
 
         toggleDebug() {
             this.enabled = !this.enabled;
-            this.toggleDebugStylesheet();
             if (this.enabled) {
                 this.setupEventListeners();
             }
@@ -22,58 +22,40 @@ if (!window.turboFrameDebug) {
             }
         }
 
-        toggleDebugStylesheet() {
-            const href = chrome.runtime.getURL(this.debugStylesheetPath)
-            const linkElement = document.querySelectorAll('link[href="' + href + '"]')[0]
-            const turboFrames = document.querySelectorAll('turbo-frame')
-
-            if (!turboFrames.length) return
-
-            if (linkElement) {
-                linkElement.remove()
-            } else {
-                const head = document.getElementsByTagName('head')[0]
-                const link = document.createElement('link')
-                link.rel = 'stylesheet'
-                link.type = 'text/css'
-                link.href = chrome.runtime.getURL(this.debugStylesheetPath)
-                head.appendChild(link)
-            }
-        }
-
         setupEventListeners() {
-            document.addEventListener('turbo:click', this.handleTurboClick)
-            document.addEventListener('turbo:before-fetch-response', this.handleTurboBeforeFetchResponse)
+            document.addEventListener('turbo:click', this.handleTurboClick);
+            document.addEventListener('turbo:before-prefetch', this.handleTurboBeforePrefetch);
+            document.addEventListener('turbo:before-fetch-request', this.handleTurboBeforeFetchRequest);
             document.addEventListener('turbo:before-stream-render', this.handleTurboBeforeStreamRender);
         }
 
         removeEventListeners() {
-            document.removeEventListener('turbo:click', this.handleTurboClick)
-            document.removeEventListener('turbo:before-fetch-response', this.handleTurboBeforeFetchResponse)
+            document.removeEventListener('turbo:click', this.handleTurboClick);
+            document.removeEventListener('turbo:before-prefetch', this.handleTurboBeforePrefetch);
+            document.removeEventListener('turbo:before-fetch-request', this.handleTurboBeforeFetchRequest);
             document.removeEventListener('turbo:before-stream-render', this.handleTurboBeforeStreamRender);
         }
 
         handleTurboClick(event) {
             const frameId = this.getFrameId(event.target);
-
             console.log(`%c${event.target.innerText}`,
                 'font-weight: bold; text-decoration: underline;',
                 'click was intercepted by Turbo which will',
-                `replace the contents of #${frameId} with the contents of <turbo-frame id="${frameId}"></turbo-frame> returned from ${event.target.getAttribute('href')}`,
+                `replace the contents of #${frameId} with the contents of <turbo-frame id="${frameId}"></turbo-frame> returned from ${event.detail.url}`,
                 event)
 
         }
 
-        handleTurboBeforeFetchResponse(event) {
-            const frameId = event.target.id;
-            if (frameId) {
-                console.log(`Turbo is replacing the contents of #${event.target.id} with the contents of <turbo-frame id="${frameId}"></turbo-frame> returned from ${event.target.getAttribute('src')}`,
-                    event);
-            }
-            else {
-                console.log(`Turbo is replacing the contents of the ${event.target.localName} element`,
-                    event);
-            }
+        handleTurboBeforePrefetch(event) {
+            console.log(`%c${event.target.innerText}`,
+            'font-weight: bold; text-decoration: underline;',
+            'hover was intercepted by Turbo which will',
+            `prefetch.`,
+            event);
+        }
+
+        handleTurboBeforeFetchRequest(event) {
+            console.log(`Turbo is fetching ${event.detail.url}`, event);
         }
 
         handleTurboBeforeStreamRender(event) {

--- a/turbo-frame/debug.js
+++ b/turbo-frame/debug.js
@@ -5,6 +5,7 @@ class TurboDebugLogger {
         this.handleTurboClick = this.handleTurboClick.bind(this);
         this.handleTurboVisit = this.handleTurboVisit.bind(this);
         this.handleTurboLoad = this.handleTurboLoad.bind(this);
+        this.handleTurboFrameRender = this.handleTurboFrameRender.bind(this);
         this.handleTurboBeforePrefetch = this.handleTurboBeforePrefetch.bind(this);
         this.handleTurboBeforeFetchRequest = this.handleTurboBeforeFetchRequest.bind(this);
         this.handleTurboBeforeStreamRender = this.handleTurboBeforeStreamRender.bind(this);
@@ -16,6 +17,7 @@ class TurboDebugLogger {
         document.addEventListener('turbo:click', this.handleTurboClick);
         document.addEventListener('turbo:visit', this.handleTurboVisit);
         document.addEventListener('turbo:load', this.handleTurboLoad);
+        document.addEventListener('turbo:frame-render', this.handleTurboFrameRender);
         document.addEventListener('turbo:before-prefetch', this.handleTurboBeforePrefetch);
         document.addEventListener('turbo:before-fetch-request', this.handleTurboBeforeFetchRequest);
         document.addEventListener('turbo:before-stream-render', this.handleTurboBeforeStreamRender);
@@ -25,6 +27,7 @@ class TurboDebugLogger {
         document.removeEventListener('turbo:click', this.handleTurboClick);
         document.removeEventListener('turbo:visit', this.handleTurboVisit);
         document.removeEventListener('turbo:load', this.handleTurboLoad);
+        document.removeEventListener('turbo:frame-render', this.handleTurboFrameRender);
         document.removeEventListener('turbo:before-prefetch', this.handleTurboBeforePrefetch);
         document.removeEventListener('turbo:before-fetch-request', this.handleTurboBeforeFetchRequest);
         document.removeEventListener('turbo:before-stream-render', this.handleTurboBeforeStreamRender);
@@ -63,6 +66,14 @@ class TurboDebugLogger {
             `\nRequest start: ${new Date(event.detail.timing.requestStart).toISOString()}`,
             `\nRequest end: ${new Date(event.detail.timing.requestEnd).toISOString()}`,
             `\nVisit end: ${new Date(event.detail.timing.visitEnd).toISOString()}`,
+        );
+    }
+
+    handleTurboFrameRender(event) {
+        const frameId = event.target.id;
+        this.logMessage(event,
+            `Rendered frame #${frameId} with the contents of the template received from`,
+            event.detail.fetchResponse.response.url
         );
     }
 

--- a/turbo-frame/debug.js
+++ b/turbo-frame/debug.js
@@ -1,0 +1,59 @@
+if (!window.turboFrameDebug) {
+
+    class TurboFrameDebug {
+
+        constructor() {
+            this.debugStylesheetPath = 'turbo-frame/debug.css';
+            this.enabled = false;
+        }
+
+        toggleDebug() {
+            this.enabled = !this.enabled;
+            this.toggleDebugStylesheet();
+            if (this.enabled) {
+                this.setupEventListeners();
+            }
+            else {
+                this.removeEventListeners();
+
+            }
+        }
+
+        toggleDebugStylesheet() {
+            const href = chrome.runtime.getURL(this.debugStylesheetPath)
+            const linkElement = document.querySelectorAll('link[href="' + href + '"]')[0]
+            const turboFrames = document.querySelectorAll('turbo-frame')
+
+            if (!turboFrames.length) return
+
+            if (linkElement) {
+                linkElement.remove()
+            } else {
+                const head = document.getElementsByTagName('head')[0]
+                const link = document.createElement('link')
+                link.rel = 'stylesheet'
+                link.type = 'text/css'
+                link.href = chrome.runtime.getURL(this.debugStylesheetPath)
+                head.appendChild(link)
+            }
+        }
+
+        setupEventListeners() {
+            document.addEventListener('turbo:before-fetch-response', this.handleTurboBeforeFetchResponse)
+            console.log('Event listeners added')
+        }
+
+        removeEventListeners() {
+            document.removeEventListener('turbo:before-fetch-response', this.handleTurboBeforeFetchResponse)
+            console.log('Event listeners removed')
+        }
+
+
+        handleTurboBeforeFetchResponse(event) {
+            console.log('turbo:before-fetch-response', event)
+        }
+    }
+
+    window.turboFrameDebug = new TurboFrameDebug();
+}
+window.turboFrameDebug.toggleDebug();

--- a/turbo-frame/debug.js
+++ b/turbo-frame/debug.js
@@ -4,6 +4,7 @@ class TurboDebugLogger {
     constructor() {
         this.handleTurboClick = this.handleTurboClick.bind(this);
         this.handleTurboVisit = this.handleTurboVisit.bind(this);
+        this.handleTurboLoad = this.handleTurboLoad.bind(this);
         this.handleTurboBeforePrefetch = this.handleTurboBeforePrefetch.bind(this);
         this.handleTurboBeforeFetchRequest = this.handleTurboBeforeFetchRequest.bind(this);
         this.handleTurboBeforeStreamRender = this.handleTurboBeforeStreamRender.bind(this);
@@ -13,7 +14,8 @@ class TurboDebugLogger {
 
     setupEventListeners() {
         document.addEventListener('turbo:click', this.handleTurboClick);
-        document.addEventListener('turbo:visit', this.handleTurboVisit);        
+        document.addEventListener('turbo:visit', this.handleTurboVisit);
+        document.addEventListener('turbo:load', this.handleTurboLoad);
         document.addEventListener('turbo:before-prefetch', this.handleTurboBeforePrefetch);
         document.addEventListener('turbo:before-fetch-request', this.handleTurboBeforeFetchRequest);
         document.addEventListener('turbo:before-stream-render', this.handleTurboBeforeStreamRender);
@@ -21,6 +23,8 @@ class TurboDebugLogger {
 
     removeEventListeners() {
         document.removeEventListener('turbo:click', this.handleTurboClick);
+        document.removeEventListener('turbo:visit', this.handleTurboVisit);
+        document.removeEventListener('turbo:load', this.handleTurboLoad);
         document.removeEventListener('turbo:before-prefetch', this.handleTurboBeforePrefetch);
         document.removeEventListener('turbo:before-fetch-request', this.handleTurboBeforeFetchRequest);
         document.removeEventListener('turbo:before-stream-render', this.handleTurboBeforeStreamRender);
@@ -42,7 +46,7 @@ class TurboDebugLogger {
             const frameId = this.getFrameId(event.target);
             clickMessage = `replace the contents of #${frameId} with the contents of <turbo-frame id="${frameId}"></turbo-frame> returned from ${event.detail.url}`;
         }
-        this.logMessage(event, 
+        this.logMessage(event,
             `Link with text "${event.target.innerText}" click was intercepted. Turbo will`,
             clickMessage);
     }
@@ -50,6 +54,16 @@ class TurboDebugLogger {
     handleTurboVisit(event) {
         this.logMessage(event,
             `Navigating to ${event.detail.url} with action "${event.detail.action}".`);
+    }
+
+    handleTurboLoad(event) {
+        this.logMessage(event,
+            `Loaded page from ${event.detail.url}.`,
+            `\nVisit start: ${new Date(event.detail.timing.visitStart).toISOString()}`,
+            `\nRequest start: ${new Date(event.detail.timing.requestStart).toISOString()}`,
+            `\nRequest end: ${new Date(event.detail.timing.requestEnd).toISOString()}`,
+            `\nVisit end: ${new Date(event.detail.timing.visitEnd).toISOString()}`,
+        );
     }
 
     handleTurboBeforePrefetch(event) {
@@ -67,7 +81,7 @@ class TurboDebugLogger {
         openingTag += '>';
 
         this.logMessage(event,
-            `Triggered by ${openingTag}, executing ${event.detail.fetchOptions.method} against ${event.detail.url}`);
+            `Triggered by ${openingTag}, \nexecuting ${event.detail.fetchOptions.method} against ${event.detail.url}`);
     }
 
     handleTurboBeforeStreamRender(event) {

--- a/turbo-frame/debug.js
+++ b/turbo-frame/debug.js
@@ -5,6 +5,9 @@ if (!window.turboFrameDebug) {
         constructor() {
             this.debugStylesheetPath = 'turbo-frame/debug.css';
             this.enabled = false;
+            this.handleTurboClick = this.handleTurboClick.bind(this);
+            this.handleTurboBeforeFetchResponse = this.handleTurboBeforeFetchResponse.bind(this);
+            this.handleTurboBeforeStreamRender = this.handleTurboBeforeStreamRender.bind(this);
         }
 
         toggleDebug() {
@@ -39,19 +42,65 @@ if (!window.turboFrameDebug) {
         }
 
         setupEventListeners() {
+            document.addEventListener('turbo:click', this.handleTurboClick)
             document.addEventListener('turbo:before-fetch-response', this.handleTurboBeforeFetchResponse)
-            console.log('Event listeners added')
+            document.addEventListener('turbo:before-stream-render', this.handleTurboBeforeStreamRender);
         }
 
         removeEventListeners() {
+            document.removeEventListener('turbo:click', this.handleTurboClick)
             document.removeEventListener('turbo:before-fetch-response', this.handleTurboBeforeFetchResponse)
-            console.log('Event listeners removed')
+            document.removeEventListener('turbo:before-stream-render', this.handleTurboBeforeStreamRender);
         }
 
+        handleTurboClick(event) {
+            const frameId = this.getFrameId(event.target);
+
+            console.log(`%c${event.target.innerText}`,
+                'font-weight: bold; text-decoration: underline;',
+                'click was intercepted by Turbo which will',
+                `replace the contents of #${frameId} with the contents of <turbo-frame id="${frameId}"></turbo-frame> returned from ${event.target.getAttribute('href')}`,
+                event)
+
+        }
 
         handleTurboBeforeFetchResponse(event) {
-            console.log('turbo:before-fetch-response', event)
+            const frameId = event.target.id;
+            if (frameId) {
+                console.log(`Turbo is replacing the contents of #${event.target.id} with the contents of <turbo-frame id="${frameId}"></turbo-frame> returned from ${event.target.getAttribute('src')}`,
+                    event);
+            }
+            else {
+                console.log(`Turbo is replacing the contents of the ${event.target.localName} element`,
+                    event);
+            }
         }
+
+        handleTurboBeforeStreamRender(event) {
+            let action = event.target.getAttribute('action');
+            if (action == 'before' || action == 'after') {
+                console.log(`Turbo has received a stream of html that will insert the contents of the template received ${action} the contents of #${event.target.getAttribute('target')}`, event)
+            }
+            else {
+                console.log(`Turbo has received a stream of html that will ${action} the contents of #${event.target.getAttribute('target')} with the contents of the template received`, event)
+            }
+
+        }
+
+        getFrameId(element) {
+            const frameId = element.getAttribute('data-turbo-frame');
+            if (!frameId) {
+                while (element.parentElement) {
+                    if (element.localName === 'turbo-frame') {
+                        const parentFrameId = element.id;
+                        return parentFrameId;
+                    }
+                    element = element.parentElement;
+                }
+            }
+            return frameId;
+        }
+
     }
 
     window.turboFrameDebug = new TurboFrameDebug();

--- a/turbo-frame/debug.js
+++ b/turbo-frame/debug.js
@@ -60,12 +60,16 @@ class TurboDebugLogger {
     }
 
     handleTurboLoad(event) {
+        const visitStart = event.detail.timing.visitStart ? new Date(event.detail.timing.visitStart).toISOString() : '';
+        const requestStart = event.detail.timing.requestStart ? new Date(event.detail.timing.requestStart).toISOString() : '';
+        const requestEnd = event.detail.timing.requestEnd ? new Date(event.detail.timing.requestEnd).toISOString() : '';
+        const visitEnd = event.detail.timing.visitEnd ? new Date(event.detail.timing.visitEnd).toISOString() : '';
         this.logMessage(event,
             `Loaded page from ${event.detail.url}.`,
-            `\nVisit start: ${new Date(event.detail.timing.visitStart).toISOString()}`,
-            `\nRequest start: ${new Date(event.detail.timing.requestStart).toISOString()}`,
-            `\nRequest end: ${new Date(event.detail.timing.requestEnd).toISOString()}`,
-            `\nVisit end: ${new Date(event.detail.timing.visitEnd).toISOString()}`,
+            `\nVisit start: ${visitStart}`,
+            `\nRequest start: ${requestStart}`,
+            `\nRequest end: ${requestEnd}`,
+            `\nVisit end: ${visitEnd}`
         );
     }
 

--- a/turbo-frame/init.js
+++ b/turbo-frame/init.js
@@ -1,10 +1,11 @@
-if (!window.turboFrameInit) {
 
+if (!window.turboFrameInit) {
     class TurboFrameInit {
         constructor() {
             this.debugStylesheetPath = 'turbo-frame/debug.css';
             this.debugJSPath = 'turbo-frame/debug.js';
             this.enabled = false;
+
         }
 
         toggleDebug() {
@@ -21,10 +22,7 @@ if (!window.turboFrameInit) {
 
             if (!turboFrames.length) return
 
-            if (linkElement) {
-                linkElement.remove();
-                scriptElement.remove();
-            } else {
+            if (this.enabled) {
                 const head = document.getElementsByTagName('head')[0]
                 const link = document.createElement('link')
                 link.rel = 'stylesheet'
@@ -32,11 +30,19 @@ if (!window.turboFrameInit) {
                 link.href = href;
                 head.appendChild(link);
 
-                var script = document.createElement('script');
-                script.src = src;
-                document.head.appendChild(script);
+                if (!scriptElement) {
+                    const script = document.createElement('script');
+                    script.src = src;
+                    document.head.appendChild(script);
+                }
+
+            }
+            else {
+                linkElement.remove();
             }
         }
+
+
     }
 
     window.turboFrameInit = new TurboFrameInit();

--- a/turbo-frame/init.js
+++ b/turbo-frame/init.js
@@ -1,0 +1,44 @@
+if (!window.turboFrameInit) {
+
+    class TurboFrameInit {
+        constructor() {
+            this.debugStylesheetPath = 'turbo-frame/debug.css';
+            this.debugJSPath = 'turbo-frame/debug.js';
+            this.enabled = false;
+        }
+
+        toggleDebug() {
+            this.enabled = !this.enabled;
+            this.toggleDebugElements();
+        }
+
+        toggleDebugElements() {
+            const href = chrome.runtime.getURL(this.debugStylesheetPath)
+            const src = chrome.runtime.getURL(this.debugJSPath);
+            const linkElement = document.querySelectorAll('link[href="' + href + '"]')[0];
+            const turboFrames = document.querySelectorAll('turbo-frame');
+            const scriptElement = document.querySelectorAll('script[src="' + src + '"]')[0];
+
+            if (!turboFrames.length) return
+
+            if (linkElement) {
+                linkElement.remove();
+                scriptElement.remove();
+            } else {
+                const head = document.getElementsByTagName('head')[0]
+                const link = document.createElement('link')
+                link.rel = 'stylesheet'
+                link.type = 'text/css'
+                link.href = href;
+                head.appendChild(link);
+
+                var script = document.createElement('script');
+                script.src = src;
+                document.head.appendChild(script);
+            }
+        }
+    }
+
+    window.turboFrameInit = new TurboFrameInit();
+}
+window.turboFrameInit.toggleDebug();


### PR DESCRIPTION
## Purpose
When troubleshooting Turbo, sometimes it's helpful to see the events happening on the client side in addition to reading the server logs. This adds logging for some of the most common events, with messages tailored for troubleshooting/visibility.

## Approach
Borrowed from [here](https://gist.github.com/schmijos/12090ed79932993b40d90bfce70eed4a?permalink_comment_id=4725881#gistcomment-4725881) 
